### PR TITLE
feat: add DaemonRpc property client

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,11 @@ dart pub add monero_rpc
 ## Usage
 
 ```
+import 'package:http/http.dart';
 import 'package:monero_rpc/src/daemon_rpc.dart';
 
 void main() async {
-  final daemonRpc = DaemonRpc(
+  final daemonRpc = DaemonRpc(Client(),
     'http://localhost:18081/json_rpc', // Replace with your Monero daemon URL.
     username: 'user', // Replace with your username.
     password: 'password', // Replace with your password.

--- a/example/monero_rpc_example.dart
+++ b/example/monero_rpc_example.dart
@@ -1,17 +1,19 @@
 import 'dart:convert';
 
+import 'package:http/http.dart';
 import 'package:monero_rpc/src/daemon_rpc.dart';
 import 'package:monero_rpc/src/utils.dart';
 
 void main() async {
   // Authenticated example:
-  // final daemonRpc = DaemonRpc(
+  // final daemonRpc = DaemonRpc(Client(),
   //   'http://localhost:18081/json_rpc', // Replace with your Monero daemon URL.
   //   username: 'user', // Replace with your username.
   //   password: 'password', // Replace with your password.
   // );
-
-  final daemonRpc = DaemonRpc('http://monero.stackwallet.com:18081/json_rpc');
+  final client = Client();
+  final daemonRpc =
+      DaemonRpc(client, 'http://monero.stackwallet.com:18081/json_rpc');
 
   try {
     // Call get_info via /json_rpc.

--- a/lib/src/daemon_rpc.dart
+++ b/lib/src/daemon_rpc.dart
@@ -11,9 +11,10 @@ class DaemonRpc {
   final String rpcUrl;
   final String? username;
   final String? password;
+  final http.Client client;
   late final String baseUrl;
 
-  DaemonRpc(this.rpcUrl, {String? username, String? password})
+  DaemonRpc(this.client, this.rpcUrl, {String? username, String? password})
       : username =
             (username != null && username.trim().isNotEmpty) ? username : null,
         password =
@@ -27,7 +28,6 @@ class DaemonRpc {
   /// digest authentication.  Otherwise, just do a single request without auth.
   Future<Map<String, dynamic>> call(
       String method, Map<String, dynamic> params) async {
-    final http.Client client = http.Client();
     final String rpcUrl = this.rpcUrl;
 
     // If credentials not provided, just try one request without auth.
@@ -119,7 +119,6 @@ class DaemonRpc {
   /// If credentials are provided, use digest authentication.
   Future<Map<String, dynamic>> postToEndpoint(
       String endpoint, Map<String, dynamic> params) async {
-    final http.Client client = http.Client();
     final fullUrl = '$baseUrl$endpoint';
 
     // Initial request

--- a/test/daemon_rpc_test.dart
+++ b/test/daemon_rpc_test.dart
@@ -1,9 +1,11 @@
+import 'package:http/http.dart';
 import 'package:monero_rpc/src/daemon_rpc.dart';
 import 'package:test/test.dart';
 
 void main() {
   test('WalletRpc call method', () async {
     final walletRpc = DaemonRpc(
+      Client(),
       'http://localhost:18081/json_rpc',
       username: 'user',
       password: 'password',


### PR DESCRIPTION
Use a provided class implementing http.Client to execute the requests.

It has a few advantages: allows to use the configuration of the provided Client and prevent creating a client for each call.

I thought about making the Client optional and still create one inside the methods in case it wasn't provided, but I think forcing to give one to the constructor will result in cleaner code and better uses of the library.
